### PR TITLE
add Go 1.22 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,8 @@ jobs:
           - windows-latest
           - macOS-latest
         go:
-          - "1"
+          - "stable"
+          - "1.22"
           - "1.21"
           - "1.20"
           - "1.19"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Go version specifications in the CI workflow for enhanced compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->