### PR TITLE
add Go 1.23 to the build matrix

### DIFF
--- a/.github/workflows/release-v1.yml
+++ b/.github/workflows/release-v1.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: "1.23"
           cache-dependency-path: go.sum
 
       - name: Configure AWS Credentials

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: "1.23"
           cache-dependency-path: v2/go.sum
 
       - name: Configure AWS Credentials

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
           - macOS-latest
         go:
           - "stable"
+          - "1.23"
           - "1.22"
           - "1.21"
           - "1.20"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Go version used in the GitHub Actions workflows to ensure consistency and predictability in the build process.
	- Expanded the testing matrix to include Go version 1.23, enhancing compatibility and robustness in testing.

- **Bug Fixes**
	- Addressed potential compatibility issues by specifying a fixed Go version instead of using the latest stable release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->