### PR TITLE
add Go 1.24 to the build matrix

### DIFF
--- a/.github/workflows/release-v1.yml
+++ b/.github/workflows/release-v1.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
           cache-dependency-path: go.sum
 
       - name: Configure AWS Credentials

--- a/.github/workflows/release-v2.yml
+++ b/.github/workflows/release-v2.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
           cache-dependency-path: v2/go.sum
 
       - name: Configure AWS Credentials

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
           - macOS-latest
         go:
           - "stable"
+          - "1.24"
           - "1.23"
           - "1.22"
           - "1.21"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded our build and testing environment to support Go 1.24, ensuring enhanced compatibility and extended testing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->