### PR TITLE
add Go 1.25 to the build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache-dependency-path: go.sum
 
       - name: Configure AWS Credentials

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
           - macOS-latest
         go:
           - "stable"
+          - "1.25"
           - "1.24"
           - "1.23"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to use Go 1.25.
  * Expanded CI test matrix to include Go 1.25 alongside existing versions.

* **Tests**
  * Ensured automated tests run against Go 1.25 for broader version coverage.

* **Documentation**
  * No user-facing documentation changes.

* **Bug Fixes**
  * No bug fixes included.

* **New Features**
  * No new features introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->