### PR TITLE
drop support of Go 1.24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
           - "stable"
           - "1.26"
           - "1.25"
-          - "1.24"
 
     steps:
       - name: Check out code into the Go module directory


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the testing matrix to verify compatibility with the latest stable Go version and versions 1.26 and 1.25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->